### PR TITLE
v3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
-## 3.3.2 - Released on ....-..-..
+## 3.3.2 - Released on 2024-12-20
 
 ### Features
 - In the `hideEverything` method, a binding has been added to the accordion selector from which the method is called.
 
 ### Changes
 - Removed the warning output to the console if there are no accordions on the page.
-...
 
 
 ## 3.3.1 - Released on 2024-12-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.3.2 - Released on ....-..-..
+
+### Features
+- In the `hideEverything` method, a binding has been added to the accordion selector from which the method is called.
+
+### Changes
+- Removed the warning output to the console if there are no accordions on the page.
+...
+
+
 ## 3.3.1 - Released on 2024-12-20
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Changes
 - Removed the warning output to the console if there are no accordions on the page.
 
+### Docs
+- Updated documentation.
+
 
 ## 3.3.1 - Released on 2024-12-20
 

--- a/README.md
+++ b/README.md
@@ -431,8 +431,8 @@ button.addEventListener("click", () => {
       <td>Method for closing all accordions in the specified container. Accepts a selector or DOM element of the container in which to search.</td>
     </tr>
     <tr>
-      <td><code>kordion.hideEverything()</code></td>
-      <td>Method to close all accordions on a page.</td>
+      <td><code>kordion.hideEverything(thisSelector)</code></td>
+      <td>Method to close all accordions on a page. <code>thisSelector</code> takes a Boolean value, if <code>true</code>, it will be called only for the accordions from which the call occurs, if <code>false</code>, then for ALL accordions on the page, without reference to the accordion from which the call occurs. Default: <code>true</code></td>
     </tr>
     <tr>
       <td><code>kordion.off(eventName, handler)</code></td>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kordion",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Contemporary style and functionality - an accordion that does more.",
   "type": "module",
   "main": "./dist/kordion.mjs",

--- a/src/core/core.mjs
+++ b/src/core/core.mjs
@@ -24,10 +24,6 @@ class Kordion {
 
       this.$kordions = document.querySelectorAll(this.selector);
 
-      if (!this.$kordions.length) {
-        console.warn("No elements found matching the selector");
-      }
-
       const lineByLineOptions = {
         speed: 350,
         easing: "cubic-bezier(.25,.1,.25,1)",
@@ -443,10 +439,11 @@ class Kordion {
   }
 
   // Скрытие всех аккордеонов на странице | Hiding all accordions
-  hideEverything() {
-    document.querySelectorAll(`.${this.settings.activeClass}`).forEach((element) => {
-      this.hide(this.createInstance(element));
-    });
+  hideEverything(thisSelector = true) {
+    document.querySelectorAll(`${thisSelector ? this.selector : ""}.${this.settings.activeClass}`)
+      .forEach((element) => {
+        this.hide(this.createInstance(element));
+      });
   }
 
   // Замена иконки аккордеона | Replacing the accordion icon


### PR DESCRIPTION
### Features
- In the `hideEverything` method, a binding has been added to the accordion selector from which the method is called.

### Changes
- Removed the warning output to the console if there are no accordions on the page.

### Docs
- Updated documentation.